### PR TITLE
Incorporate catalog images into prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An automated service that generates daily on-brand graphics for Apes On Keys by:
 
-1. Pulling product & grid images from Shopify and the a-ok.shop gallery API
+1. Pulling product & grid images from Shopify and the a-ok.shop gallery API and summarising them with GPT-4o Vision
 2. Generating fresh graphics using OpenAI's DALL-E 3
 3. Storing the results in the local repo under `public/daily/`
 4. Updating a manifest of generated images
@@ -53,6 +53,7 @@ GitHub Actions (cron)
    └─▶ Node script (src/index.ts)
          ├─ fetchShopifyMedia.ts  ← Storefront GraphQL API
          ├─ listGridImages.ts  ← a-ok.shop gallery API
+         ├─ describeImage.ts    ← GPT-4o Vision summaries
          ├─ craftPrompt.ts       ← brand rules + descriptors
          ├─ generateImage.ts     ← OpenAI imagegen 1×1024 PNG
          └─ manifest.json update + Vercel Deploy Hook

--- a/src/craftPrompt.ts
+++ b/src/craftPrompt.ts
@@ -1,7 +1,8 @@
 const BRAND_RULES = `
 Apes On Keys street-art; bold red/black/white; mid-century Hitchcock poster vibe; stencil feel; print-ready;
 large letters only; max 4 words; no paragraphs; no fake UI; high-contrast; AGI themes;
-no lorem ipsum; no techno babble; no multiple text boxes; avoid filler text;`;
+no lorem ipsum; no techno babble; no multiple text boxes; avoid filler text;
+inspired by product copy, catalog imagery and a-ok-shop project photos;`;
 
 export function makePrompt(descriptors: string[]) {
   const validDescriptors = descriptors

--- a/src/describeImage.ts
+++ b/src/describeImage.ts
@@ -1,0 +1,31 @@
+import OpenAI from "openai";
+
+const openai = new OpenAI();
+
+export async function describeImage(url: string): Promise<string> {
+  try {
+    const result = await openai.chat.completions.create({
+      model: "gpt-4o",
+      max_tokens: 20,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Briefly describe this image in under 8 words.",
+            },
+            {
+              type: "image_url",
+              image_url: { url },
+            },
+          ],
+        },
+      ],
+    });
+    return result.choices[0]?.message?.content?.trim() || "";
+  } catch (err) {
+    console.error("describeImage error", err);
+    return "";
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { getProductMedia } from "./fetchShopifyMedia";
 import { listGridImages } from "./listGridImages";
 import { makePrompt } from "./craftPrompt";
 import { generateImage } from "./generateImage";
+import { describeImage } from "./describeImage";
 import fs from "fs/promises";
 
 function generateRandomHash(length: number = 4): string {
@@ -35,10 +36,28 @@ async function main() {
       listGridImages(),
     ]);
 
+    function sample<T>(arr: T[], count: number): T[] {
+      const copy = [...arr];
+      const out: T[] = [];
+      for (let i = 0; i < count && copy.length; i++) {
+        const idx = Math.floor(Math.random() * copy.length);
+        out.push(copy.splice(idx, 1)[0]);
+      }
+      return out;
+    }
+
+    const sampledShopify = sample(shopifyMedia, 3);
+    const sampledGrid = sample(gridMedia, 3);
+
+    const imageDescriptions = await Promise.all(
+      [...sampledShopify, ...sampledGrid].map((img) => describeImage(img.url))
+    );
+
     const allDescriptors = [
       ...shopifyMedia.map((m) => m.alt),
       ...shopifyMedia.map((m) => m.description),
       ...gridMedia.map((m: GridImage) => m.alt),
+      ...imageDescriptions,
     ];
 
     // 3. Build prompt

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
     "outDir": "dist",
     "rootDir": "src",
     "allowImportingTsExtensions": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"],
+    "typeRoots": ["./node_modules/@types"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- add `describeImage` for GPT-4o Vision analysis of images
- sample catalog and gallery images, summarise them and feed descriptors into the prompt
- mention catalog imagery in brand rules
- document Vision summarisation in README
- update tsconfig settings

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*